### PR TITLE
ruijie,rg-x60-new: dts: replace model value with more appropriate content

### DIFF
--- a/uboot-mtk-20250711/arch/arm/dts/mediatek/nonmbm/mt7986a-ruijie-rg-x60-new.dts
+++ b/uboot-mtk-20250711/arch/arm/dts/mediatek/nonmbm/mt7986a-ruijie-rg-x60-new.dts
@@ -4,6 +4,6 @@
 #include "mt7986a-ruijie-rg-x60.dtsi"
 
 / {
-	model = "mt7986-ruijie-rg-x60-new";
-	compatible = "mediatek,mt7986", "mediatek,mt7986-rfb";
+	model = "Ruijie RG-X60 New";
+	compatible = "ruijie,rg-x60-new", "mediatek,mt7986a";
 };

--- a/uboot-mtk-20250711/arch/arm/dts/mt7986a-ruijie-rg-x60-new.dts
+++ b/uboot-mtk-20250711/arch/arm/dts/mt7986a-ruijie-rg-x60-new.dts
@@ -4,6 +4,6 @@
 #include "mt7986a-ruijie-rg-x60.dtsi"
 
 / {
-	model = "mt7986-ruijie-rg-x60-new";
-	compatible = "mediatek,mt7986", "mediatek,mt7986-rfb";
+	model = "Ruijie RG-X60 New";
+	compatible = "ruijie,rg-x60-new", "mediatek,mt7986a";
 };


### PR DESCRIPTION
In order to display more appropriate model type in booting log.

```diff
U-Boot 2025.07.1-Mediatek (Jun 06 2026 - 18:01:08 +0800)

CPU:   MediaTek MT7986
-Model: mt7986-ruijie-rg-x60-new
-       (mediatek,mt7986-rfb)
+Model: Ruijie RG-X60 New
+       (mediatek,mt7986a)
DRAM:  512 MiB
```